### PR TITLE
fix: export types for TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "exports": {
     "import": "./exports/import.mjs",
-    "require": "./exports/require.cjs"
+    "require": "./exports/require.cjs",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "/dist",


### PR DESCRIPTION
When TS is in non-default `moduleResolution` mode, it would read the `exports` and wouldn't find the types.